### PR TITLE
Landing page tweak: 100svh

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,7 +1,7 @@
 .home {
   background-color: var(--color-white);
   width: 100%;
-  height: 100vh;
+  height: 100svh;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
Switching landing page height to 100svh to avoid unnecessary vertical scroll on mobile devices