### PR TITLE
Make 'see more' modal scrollable for large content

### DIFF
--- a/src/components/see-more-button/see-more-button.tsx
+++ b/src/components/see-more-button/see-more-button.tsx
@@ -69,7 +69,7 @@ export default function SeeMoreButton({
       <DialogTrigger className="ml-1 text-sky-600 hover:text-sky-700">
         See More
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="max-h-[600px] md:max-h-[750px] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>About</DialogTitle>
           <DialogDescription className="whitespace-pre-line">


### PR DESCRIPTION
Previously, long 'see more' text content would overflow off the viewport. This prevents that by capping height based on device size and adding y-axis scroll.