### PR TITLE
Update DSF user name / image if changed on Twitter

### DIFF
--- a/src/lib/utils/process.ts
+++ b/src/lib/utils/process.ts
@@ -58,6 +58,29 @@ export async function handleSignIn() {
       }
 
       initialSignIn = true;
+    } else {
+      // if avatar or username has changed, since last sign-in, update accordingly
+
+      let highResCurrentUserImageUrl = currentUser.twitterAvatarURL.replace(
+        "_normal",
+        "_400x400"
+      );
+      if (
+        userData.twitter_avatar_url !== highResCurrentUserImageUrl ||
+        userData.name !== currentUser.twitterName
+      ) {
+        const { error } = await supabase
+          .from("users")
+          .update({
+            twitter_avatar_url: highResCurrentUserImageUrl,
+            name: currentUser.twitterName,
+          })
+          .eq("user_id", currentUser.userID);
+
+        if (error) {
+          console.error(error);
+        }
+      }
     }
 
     // await refreshTwitterFollowsIfNeeded(


### PR DESCRIPTION
### Problem
Users will occasionally change their name/avatar on Twitter. This doesn't update on DirectorySF, and instead shows an outdated name or the image placeholder (since original avatar is removed from Twitter's CDN, which we're relying on)

### Solution
When user signs in, check if image or name in 'Users' table is inconsistent with session data (it's assumed that session data will match Twitter). If inconsistent, update record with current data.