### PR TITLE
Community Card Bugfixes

### DIFF
--- a/src/components/profile-card.tsx
+++ b/src/components/profile-card.tsx
@@ -103,21 +103,14 @@ const ProfileCard = ({ profile, color, curUserName }: ProfileCardProps) => {
   };
 
   useEffect(() => {
-    if (isCommunityProfile(profile) && profile.user_id) {
-      getImageLink(profile.user_id)
-        .then((url: string | Error) => {
-          if (typeof url === "string") {
-            setImageUrl(url);
-          }
-        })
-        .catch((error) => console.error("Error fetching image:", error));
-    }
     const fetchReferrer = async () => {
-      try {
-        const referrerData = await getReferrerName(profile.user_id ?? "");
-        if (referrerData) setReferrer(referrerData);
-      } catch (error) {
-        console.error(error);
+      if (profile.user_id) {
+        try {
+          const referrerData = await getReferrerName(profile.user_id);
+          if (referrerData) setReferrer(referrerData);
+        } catch (error) {
+          console.error(error);
+        }
       }
     };
 
@@ -304,22 +297,19 @@ const ProfileCard = ({ profile, color, curUserName }: ProfileCardProps) => {
         }
       }
 
+      const communityImageURL = profile.image_url || user?.twitter_avatar_url;
+
       return (
         <li className={styles.frameParent} id="profile-card-element">
           <div className={styles.image3Parent}>
-            {imageUrl ? (
+            {communityImageURL ? (
               <img
                 className={styles.image3Icon}
-                alt=""
-                src={imageUrl || undefined}
-              />
-            ) : user?.twitter_avatar_url ? (
-              <img
-                className={styles.image3Icon}
-                alt=""
-                src={user.twitter_avatar_url}
+                alt="community image"
+                src={communityImageURL}
               />
             ) : null}
+
             <div className={styles.frameGroup}>
               {/* <ContactMeButton contactMethod={contactMethod} color={color} /> */}
               <Link

--- a/src/lib/utils/data.ts
+++ b/src/lib/utils/data.ts
@@ -102,15 +102,12 @@ export async function getOrganizerProfiles(
 }
 
 export async function getCommunities(startIdx: number = 0, count: number = 25) {
-  const { data, error } = await supabase
-    .from("communities")
-    .select(
-      `
+  const { data, error } = await supabase.from("communities").select(
+    `
       *, user:users(name, twitter_handle, twitter_avatar_url)
     `
-    )
-    .range(startIdx, startIdx + count);
-  // .eq("housing_search_profiles.user_id", "follow_intersections.user_id_1");
+  );
+  // .range(startIdx, startIdx + count);
 
   if (error) {
     console.error(error);


### PR DESCRIPTION
- Uses image URL saved in the community profile's DB record, rather than scanning image storage each time. This substantially improves card load time
- Removes 25 profile count cap from `getCommunities()` function, thereby allowing all communities to be pulled at once