### PR TITLE
Update timestamp function

### DIFF
--- a/src/lib/utils/general.ts
+++ b/src/lib/utils/general.ts
@@ -1,30 +1,17 @@
 export function getCurrentTimestamp() {
   const now = new Date();
 
-  // Get the date components
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
+  // Convert to UTC
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
+  const hours = String(now.getUTCHours()).padStart(2, "0");
+  const minutes = String(now.getUTCMinutes()).padStart(2, "0");
+  const seconds = String(now.getUTCSeconds()).padStart(2, "0");
+  const milliseconds = String(now.getUTCMilliseconds()).padStart(3, "0");
 
-  // Get the time components
-  const hours = String(now.getHours()).padStart(2, "0");
-  const minutes = String(now.getMinutes()).padStart(2, "0");
-  const seconds = String(now.getSeconds()).padStart(2, "0");
-  const milliseconds = String(now.getMilliseconds()).padStart(3, "0");
-
-  // Get the time zone offset
-  const offsetHours = String(Math.floor(now.getTimezoneOffset() / 60)).padStart(
-    2,
-    "0"
-  );
-  const offsetMinutes = String(Math.abs(now.getTimezoneOffset() % 60)).padStart(
-    2,
-    "0"
-  );
-  const offsetSign = now.getTimezoneOffset() > 0 ? "-" : "+";
-
-  // Construct the timestamp string
-  const timestamp = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}${offsetSign}${offsetHours}:${offsetMinutes}`;
+  // Construct the UTC timestamp string
+  const timestamp = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}Z`; // 'Z' denotes UTC
 
   return timestamp;
 }


### PR DESCRIPTION
Certain clients observing intermittent error wherein timezone includes both '+' and '-' before offset string. Seems to only occur in Europe.

Standardizing timezone string to UTC, which will hopefully fix the issue.