### PR TITLE
URL Safety + Staging link post-auth routing

### DIFF
--- a/src/components/cards/card-bio-section.tsx
+++ b/src/components/cards/card-bio-section.tsx
@@ -13,6 +13,7 @@ export default function CardBioSection({
 }) {
   const bioRef = useRef<HTMLParagraphElement>(null); // Create a ref for the bio paragraph
   const [isOverflowing, setIsOverflowing] = useState(false);
+  const validatedURL = link ? addProtocolToURL(link) : "";
 
   useEffect(() => {
     const checkOverflow = () => {
@@ -38,14 +39,14 @@ export default function CardBioSection({
           {isOverflowing ? (
             <SeeMoreButton color={"blue"} seeMoreText={bio ?? ""} />
           ) : null}
-          {link ? (
+          {validatedURL ? (
             <Link
-              href={addProtocolToURL(link)}
+              href={validatedURL}
               className="flex items-center"
               target="_blank"
             >
               <span className="text-neutral-500 hover:text-blue-400 max-w-[10rem] truncate">
-                {cleanURL(link)}
+                {cleanURL(validatedURL)}
               </span>
               <ExternalLink className="h-4 w-4 ml-1 text-neutral-500" />
             </Link>

--- a/src/lib/utils/auth.ts
+++ b/src/lib/utils/auth.ts
@@ -73,6 +73,9 @@ export async function signout() {
 export async function signInWithTwitter() {
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: "twitter",
+    options: {
+      redirectTo: window.location.origin,
+    },
   });
   if (error) {
     return { status: "error", message: "failed to authenticate user" };

--- a/src/lib/utils/data.ts
+++ b/src/lib/utils/data.ts
@@ -50,7 +50,6 @@ export async function getHousingSearchProfiles(
   count: number = 25,
   filters: SearcherProfilesFilterType = {}
 ) {
-  console.log("startIdx: ", startIdx, " count: ", count);
   const { leaseLength, housemateCount, movingTime } = filters;
   let query = supabase
     .from("housing_search_profiles")

--- a/src/lib/utils/general.ts
+++ b/src/lib/utils/general.ts
@@ -30,8 +30,16 @@ export function cleanURL(url: string) {
 }
 
 export function addProtocolToURL(url: string) {
-  if (!url.startsWith("http://") && !url.startsWith("https://")) {
-    return "http://" + url;
+  try {
+    let newURL = url.trim();
+    if (!newURL) {
+      return "";
+    }
+    if (!newURL.startsWith("http://") && !newURL.startsWith("https://")) {
+      newURL = "http://" + newURL;
+    }
+    return new URL(newURL).toString();
+  } catch {
+    return "";
   }
-  return url;
 }


### PR DESCRIPTION
- Updating `addProtocolToURL` utility so it only ever returns a valid URL or empty string. The below issue may have been caused by a user submitting their URL with a leading space: ' https://...' 
![image](https://github.com/tjschulz2/sf-housing-app/assets/32910906/89c70476-9e54-4279-85ec-dfc2e6cdf97f)

- Adds post-authentication redirect to verified domains (Neall's Vercel staging link), making pre-production tests easier.
- General console clean-up