### PR TITLE
Activity indicators and re-confirmation

### DIFF
--- a/src/components/active-profile-banner.tsx
+++ b/src/components/active-profile-banner.tsx
@@ -72,7 +72,6 @@ export default function ActiveProfileBanner({
           <span className="ml-2 inline-flex">
             <ActivityStatusDot
               status={deriveActivityLevel(daysSinceConfirmed || 0)}
-              // showTooltip={false}
             />
           </span>
         </CardTitle>
@@ -87,12 +86,12 @@ export default function ActiveProfileBanner({
           {confirmationPending ? (
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
           ) : null}
-          {recentlyConfirmed ? "You're all set!" : "Confirm still looking"}
+          Confirm still looking{" "}
         </Button>
 
         <p className="text-sm mt-2 text-neutral-500 dark:text-neutral-400">
           {recentlyConfirmed
-            ? `Maintain your active status by re-confirming periodically`
+            ? `You're all set! Maintain your active status by re-confirming periodically`
             : `You last confirmed ${daysSinceConfirmed} days ago`}
         </p>
       </CardContent>

--- a/src/components/active-profile-banner.tsx
+++ b/src/components/active-profile-banner.tsx
@@ -32,13 +32,11 @@ export default function ActiveProfileBanner({
   const { userHousingSearchProfile, refreshUserHousingSearchProfileData } =
     useContext(ProfilesContext) as ProfilesContextType;
 
-  let recentlyConfirmed;
-  let daysSinceConfirmed;
-  if (userHousingSearchProfile?.last_updated_date) {
-    const { diffDays } = dateDiff(userHousingSearchProfile.last_updated_date);
-    daysSinceConfirmed = diffDays;
-    recentlyConfirmed = diffDays < 1;
-  }
+  const daysSinceConfirmed = userHousingSearchProfile?.last_updated_date
+    ? dateDiff(userHousingSearchProfile.last_updated_date).diffDays
+    : null;
+  const recentlyConfirmed =
+    daysSinceConfirmed !== null ? daysSinceConfirmed < 1 : false;
 
   async function handleConfirm() {
     setConfirmationPending(true);

--- a/src/components/activity-status-dot.tsx
+++ b/src/components/activity-status-dot.tsx
@@ -16,13 +16,13 @@ export default function ActivityStatusDot({
   let tooltipContent = "";
   if (status === "high") {
     colorClass = "bg-green-600";
-    tooltipContent = "Recently confirmed actively looking";
+    tooltipContent = "Confirmed within the last week";
   } else if (status === "med") {
     colorClass = "bg-yellow-400";
-    tooltipContent = "Last confirmed looking a few weeks ago";
+    tooltipContent = "Confirmed within the last two weeks";
   } else {
     colorClass = "bg-red-500";
-    tooltipContent = "Hasn't recently confirmed as looking";
+    tooltipContent = "Last confirmed over two weeks ago";
   }
 
   if (showTooltip) {

--- a/src/components/cards/searcher-profile-card.tsx
+++ b/src/components/cards/searcher-profile-card.tsx
@@ -26,11 +26,9 @@ export default function SearcherProfileCard(props: PropsType) {
 
   const bio = profile.pref_housemate_details ?? "";
 
-  let activityLevel;
-  if (profile.last_updated_date) {
-    const { diffDays } = dateDiff(profile.last_updated_date);
-    activityLevel = deriveActivityLevel(diffDays);
-  }
+  const daysSinceConfirmation = profile.last_updated_date
+    ? dateDiff(profile.last_updated_date).diffDays
+    : null;
 
   return (
     <Card>
@@ -41,9 +39,11 @@ export default function SearcherProfileCard(props: PropsType) {
             <span className="font-semibold max-w-[12rem] truncate">
               {profile.user?.name}{" "}
             </span>
-            {activityLevel === "high" ? (
+            {daysSinceConfirmation !== null ? (
               <span className="ml-2">
-                <ActivityStatusDot status={activityLevel} />
+                <ActivityStatusDot
+                  status={deriveActivityLevel(daysSinceConfirmation)}
+                />
               </span>
             ) : null}
           </div>

--- a/src/components/cards/space-profile-card.tsx
+++ b/src/components/cards/space-profile-card.tsx
@@ -42,7 +42,7 @@ export default function SpaceProfileCard(props: PropsType) {
         />
         <div className="flex flex-col gap-4 items-center max-w-[60%]">
           <div className="w-full flex justify-center">
-            <span className="font-semibold text-ellipsis overflow-hidden text-pretty">
+            <span className="font-semibold text-ellipsis overflow-hidden text-pretty text-center">
               {profile.name}{" "}
             </span>
             {activityLevel === "high" ? (

--- a/src/components/spaces/active-space-banner.tsx
+++ b/src/components/spaces/active-space-banner.tsx
@@ -19,6 +19,7 @@ import { useAuthContext } from "@/contexts/auth-context";
 import { useSpacesContext } from "@/contexts/spaces-context";
 import { useState } from "react";
 import { confirmSpaceListingActive } from "@/lib/utils/data";
+import deriveActivityLevel from "@/lib/configMaps";
 
 export default function ActiveSpaceBanner() {
   const [confirmationPending, setConfirmationPending] = useState(false);
@@ -27,13 +28,11 @@ export default function ActiveSpaceBanner() {
   const { userSpaceListing, pullSpaceListings, pullUserSpaceListing } =
     useSpacesContext();
 
-  let recentlyConfirmed;
-  let daysSinceConfirmed;
-  if (userSpaceListing?.last_updated_date) {
-    const { diffDays } = dateDiff(userSpaceListing.last_updated_date);
-    daysSinceConfirmed = diffDays;
-    recentlyConfirmed = diffDays < 1;
-  }
+  const daysSinceConfirmed = userSpaceListing?.last_updated_date
+    ? dateDiff(userSpaceListing.last_updated_date).diffDays
+    : null;
+  const recentlyConfirmed =
+    daysSinceConfirmed !== null ? daysSinceConfirmed < 1 : false;
 
   async function handleConfirm() {
     try {
@@ -67,7 +66,9 @@ export default function ActiveSpaceBanner() {
         <CardTitle>
           You have an active listing{" "}
           <span className="ml-2 inline-flex">
-            <ActivityStatusDot status="high" />
+            <ActivityStatusDot
+              status={deriveActivityLevel(daysSinceConfirmed || 0)}
+            />
           </span>
         </CardTitle>
         <CardDescription>You can manage your space here</CardDescription>

--- a/src/components/spaces/edit-space-listing-dialog.tsx
+++ b/src/components/spaces/edit-space-listing-dialog.tsx
@@ -27,7 +27,6 @@ export default function EditSpaceListingDialog({
   newListing?: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  console.log("dialog render!");
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>

--- a/src/components/spaces/space-listing-form.tsx
+++ b/src/components/spaces/space-listing-form.tsx
@@ -137,10 +137,8 @@ export default function SpaceListingForm({
   const parseResult = formSchema.safeParse(userSpaceListing);
   const parsedSpaceData = parseResult.success ? parseResult.data : null;
   if (!parseResult.success) {
-    console.log({ parseResult });
+    console.error({ parseResult });
   }
-  console.log({ userSpaceListing });
-  console.log({ parsedSpaceData });
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),

--- a/src/lib/configMaps.ts
+++ b/src/lib/configMaps.ts
@@ -38,10 +38,10 @@ export const housingMap: Record<string, Record<number, string>> = {
 
 // Accepts the number of days since last confirmation, returns derived activity level
 export default function deriveActivityLevel(daysSinceConf: number) {
-  if (daysSinceConf <= 10) {
+  if (daysSinceConf <= 7) {
     return "high";
   }
-  if (daysSinceConf <= 20) {
+  if (daysSinceConf <= 14) {
     return "med";
   } else {
     return "low";

--- a/src/lib/utils/data.ts
+++ b/src/lib/utils/data.ts
@@ -203,6 +203,13 @@ export async function getUserSpaceListing(userID: string) {
   }
 }
 
+export async function confirmSpaceListingActive(user_id: string) {
+  return await supabase
+    .from("communities")
+    .update({ last_updated_date: getCurrentTimestamp() })
+    .eq("user_id", user_id);
+}
+
 export async function saveUserSpaceListing(
   spaceListingData: Partial<SpaceListingType>,
   userID: string

--- a/src/lib/utils/process.ts
+++ b/src/lib/utils/process.ts
@@ -154,42 +154,6 @@ async function refreshTwitterFollowsIfNeeded(
   }
 }
 
-export async function handleSignOut() {
-  console.log("trigger signout process");
-}
-
-export const getSessionData = async () => {
-  const session = await getUserSession();
-  console.log(session);
-  if (session && session.twitterID) {
-    const { data: userData, error: userError } = await supabase
-      .from("users")
-      .select("*")
-      .eq("twitter_id", session.twitterID);
-
-    if (userError) {
-      console.error("Error fetching user data:", userError.message);
-      return false;
-    }
-
-    if (userData && userData.length > 0) {
-      // Existing user, redirect to the directory page
-      await handleSignIn();
-      return true;
-      //router.push('/directory');
-    } else {
-      // New user, prompt to request an invitation
-      // or show a message indicating they need an invitation
-      signout();
-      alert("You need to be referred");
-      console.log("User needs an invitation");
-      return false;
-      // Display appropriate UI here
-    }
-  }
-  return false;
-};
-
 export const addHousingData = async (
   description: string,
   housingType: string,


### PR DESCRIPTION
- Show activity indicators for all housing search profiles.
- Update indicators so green is <= 7 days, and yellow is <= 14 days
- Add ability to confirm availability (for space profiles)
- Small language tweaks and cleanup 