### PR TITLE
Fix searcher profile card content spill

### DIFF
--- a/src/components/cards/searcher-profile-card.tsx
+++ b/src/components/cards/searcher-profile-card.tsx
@@ -37,7 +37,7 @@ export default function SearcherProfileCard(props: PropsType) {
       <CardTop>
         <UserProfileImage size="large" src={profile.user?.twitter_avatar_url} />
         <div className="flex flex-col items-center max-w-[60%]">
-          <div>
+          <div className="grid grid-cols-[1fr,25px]">
             <span className="font-semibold max-w-[12rem] truncate">
               {profile.user?.name}{" "}
             </span>


### PR DESCRIPTION
### Summary

On the `/searchers` page if a user’s name exceeds the available space it won’t truncate, but will spill out of its bounding box.

<img width="454" alt="Screenshot 2024-11-28 at 7 18 08 pm" src="https://github.com/user-attachments/assets/ca829428-9be2-442c-ab65-efad85e8305c">

Which on mobile creates a displeasing horizontal scroll.

<img width="334" alt="Screenshot 2024-11-28 at 7 19 07 pm" src="https://github.com/user-attachments/assets/dbc0c26e-511a-4a29-b9c0-be8d63be7e97">

This is despite the element having the `truncate` Tailwind class, as it’s being applied to an inline `<span>`. One solution here is use `grid`, reserve space for the activity dot, and leave the remaining for the now-truncated name.

```css
div {
    display: grid;
    grid-template-columns: 1fr 25px;
}
```

### Test Plan

Attempted to build and run, but it doesn’t seem quite amenable to that; rather edited through DevTools, and made a [minimal reproduction](https://play.tailwindcss.com/vPNEGUQjv0).

<img width="419" alt="image" src="https://github.com/user-attachments/assets/a3f92c7b-3f0e-41e3-9442-bf3e9784ed4e">
